### PR TITLE
Fix Supabase environment variables for production build

### DIFF
--- a/Dockerfile.coolify
+++ b/Dockerfile.coolify
@@ -3,6 +3,14 @@ FROM node:18-alpine AS builder
 
 WORKDIR /app
 
+# Declare build arguments for Vite environment variables
+ARG VITE_SUPABASE_URL
+ARG VITE_SUPABASE_ANON_KEY
+
+# Set environment variables from build arguments
+ENV VITE_SUPABASE_URL=$VITE_SUPABASE_URL
+ENV VITE_SUPABASE_ANON_KEY=$VITE_SUPABASE_ANON_KEY
+
 # Copy package files
 COPY package*.json ./
 COPY tsconfig.json ./
@@ -17,7 +25,7 @@ COPY client ./client
 # Install dependencies
 RUN npm install
 
-# Build the application
+# Build the application (now with VITE_* env vars available)
 RUN npm run build
 
 # Production stage

--- a/docker-compose.coolify.yml
+++ b/docker-compose.coolify.yml
@@ -31,6 +31,10 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.coolify
+      args:
+        # Pass Vite environment variables as build arguments
+        VITE_SUPABASE_URL: ${VITE_SUPABASE_URL}
+        VITE_SUPABASE_ANON_KEY: ${VITE_SUPABASE_ANON_KEY}
     restart: unless-stopped
     ports:
       - "3365:3000"


### PR DESCRIPTION
- Add ARG declarations for VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY in Dockerfile.coolify
- Pass Vite environment variables as build arguments in docker-compose.coolify.yml
- This ensures frontend Supabase client gets required env vars during build process