### PR TITLE
Fix ClamAV socket path and remove deprecated options

### DIFF
--- a/Dockerfile.coolify
+++ b/Dockerfile.coolify
@@ -51,8 +51,8 @@ RUN apk update && apk add --no-cache \
     && rm -rf /var/cache/apk/*
 
 # Create ClamAV and supervisor directories and set permissions
-RUN mkdir -p /var/lib/clamav /var/log/clamav /run/clamav /var/log/supervisor \
-    && chown -R clamav:clamav /var/lib/clamav /var/log/clamav /run/clamav
+RUN mkdir -p /var/lib/clamav /var/log/clamav /run/clamav /var/run/clamav /var/log/supervisor \
+    && chown -R clamav:clamav /var/lib/clamav /var/log/clamav /run/clamav /var/run/clamav
 
 # Copy built application
 COPY --from=builder /app/package*.json ./

--- a/docker/clamav/clamd.conf
+++ b/docker/clamav/clamd.conf
@@ -7,7 +7,7 @@ LogClean no
 LogSyslog no
 LogVerbose no
 PidFile /run/clamav/clamd.pid
-LocalSocket /run/clamav/clamd.sock
+LocalSocket /var/run/clamav/clamd.ctl
 LocalSocketGroup clamav
 LocalSocketMode 666
 FixStaleSocket yes
@@ -26,7 +26,6 @@ ExcludePath ^/sys/
 ExcludePath ^/dev/
 ExcludePath ^/run/
 User clamav
-AllowSupplementaryGroups yes
 ScanMail yes
 ScanArchive yes
 ArchiveBlockEncrypted no


### PR DESCRIPTION
- Change LocalSocket from /run/clamav/clamd.sock to /var/run/clamav/clamd.ctl
- Remove deprecated AllowSupplementaryGroups option
- Create /var/run/clamav directory for socket file
- Matches virus scanner service expectations in VirusScannerService
- Allows clamd to start properly after freshclam downloads definitions