### PR TITLE
Fix ClamAV service startup conflicts and timing

### DIFF
--- a/docker/scripts/init-clamav.sh
+++ b/docker/scripts/init-clamav.sh
@@ -36,34 +36,18 @@ EOF
 
 chmod +x /usr/local/bin/virus-action.sh
 
-# Wait for network connectivity before downloading virus definitions
+# Wait for network connectivity
 echo "Waiting for network connectivity..."
-for i in $(seq 1 30); do
+for i in $(seq 1 10); do
     if ping -c 1 database.clamav.net >/dev/null 2>&1; then
         echo "Network connectivity confirmed"
         break
     fi
-    echo "Waiting for network... ($i/30)"
-    sleep 2
+    echo "Waiting for network... ($i/10)"
+    sleep 1
 done
 
-# Download initial virus definitions if they don't exist
-if [ ! -f /var/lib/clamav/main.cvd ] && [ ! -f /var/lib/clamav/main.cld ]; then
-    echo "Downloading initial virus definitions..."
-    su-exec clamav freshclam --verbose || {
-        echo "Warning: Failed to download virus definitions. ClamAV will continue with empty database."
-        # Create minimal dummy files to allow ClamAV to start
-        touch /var/lib/clamav/main.cvd
-        touch /var/lib/clamav/daily.cvd
-        touch /var/lib/clamav/bytecode.cvd
-        chown clamav:clamav /var/lib/clamav/*.cvd
-    }
-else
-    echo "Virus definitions already exist"
-fi
-
-# Test ClamAV configuration
-echo "Testing ClamAV configuration..."
-su-exec clamav clamd --config-check=yes
+# Note: Freshclam will be managed by supervisor, not here
+echo "ClamAV directories prepared, freshclam will handle virus definitions via supervisor"
 
 echo "ClamAV initialization completed successfully" 

--- a/docker/supervisor/supervisord.conf
+++ b/docker/supervisor/supervisord.conf
@@ -38,7 +38,7 @@ priority=200
 command=/usr/sbin/clamd --foreground=true
 autostart=true
 autorestart=true
-startsecs=30
+startsecs=60
 stdout_logfile=/var/log/supervisor/clamd.log
 stderr_logfile=/var/log/supervisor/clamd.log
 user=clamav


### PR DESCRIPTION
- Remove freshclam conflict between init script and supervisor
- Increase clamd startsecs to 60 to allow freshclam time to download definitions
- Simplify init-clamav.sh to only setup directories, not download definitions
- Let supervisor freshclam handle all virus definition management
- Eliminates 'Resource temporarily unavailable' log file conflicts