### PR TITLE
Fix ClamAV log file locking conflict

### DIFF
--- a/docker/clamav/clamd.conf
+++ b/docker/clamav/clamd.conf
@@ -1,7 +1,8 @@
 # ClamAV Daemon Configuration for Docker
 # Based on Alpine Linux ClamAV package
 
-LogFile /var/log/clamav/clamd.log
+# Disable internal logging - let supervisor handle it
+# LogFile /var/log/clamav/clamd.log
 LogTime yes
 LogClean no
 LogSyslog no


### PR DESCRIPTION
- Disable internal LogFile in clamd.conf to prevent locking conflicts
- Let supervisor handle all clamd logging instead of dual logging
- Fixes 'Failed to lock the log file' error preventing clamd startup
- Eliminates 'Resource temporarily unavailable' errors
- Allows clamd daemon to start successfully