### PR TITLE
Disable ClamAV antivirus service to resolve startup issues

### DIFF
--- a/Dockerfile.coolify
+++ b/Dockerfile.coolify
@@ -1,4 +1,4 @@
-# Coolify-optimized Dockerfile for StrataTracker with ClamAV support
+# Coolify-optimized Dockerfile for StrataTracker (ClamAV disabled)
 FROM node:18-alpine AS builder
 
 WORKDIR /app
@@ -33,26 +33,16 @@ RUN echo "Build environment check:" || true && \
 # Build the application
 RUN npm run build
 
-# Production stage with ClamAV support
+# Production stage (simplified without ClamAV)
 FROM node:18-alpine AS production
 
 WORKDIR /app
 
-# Install ClamAV and required dependencies
+# Install minimal required dependencies
 RUN apk update && apk add --no-cache \
-    clamav \
-    clamav-daemon \
-    clamav-libunrar \
-    freshclam \
-    supervisor \
     curl \
-    su-exec \
     netcat-openbsd \
     && rm -rf /var/cache/apk/*
-
-# Create ClamAV and supervisor directories and set permissions
-RUN mkdir -p /var/lib/clamav /var/log/clamav /run/clamav /var/run/clamav /var/log/supervisor \
-    && chown -R clamav:clamav /var/lib/clamav /var/log/clamav /run/clamav /var/run/clamav
 
 # Copy built application
 COPY --from=builder /app/package*.json ./
@@ -60,31 +50,20 @@ COPY --from=builder /app/dist ./dist/
 COPY --from=builder /app/shared ./shared/
 COPY --from=builder /app/node_modules ./node_modules/
 
-# Copy ClamAV configuration files
-COPY docker/clamav/clamd.conf /etc/clamav/clamd.conf
-COPY docker/clamav/freshclam.conf /etc/clamav/freshclam.conf
-COPY docker/supervisor/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
-COPY docker/scripts/init-clamav.sh /usr/local/bin/init-clamav.sh
-COPY docker/scripts/health-check.sh /usr/local/bin/health-check.sh
-
-# Make scripts executable
-RUN chmod +x /usr/local/bin/init-clamav.sh /usr/local/bin/health-check.sh
-
 # Create necessary directories
-RUN mkdir -p /app/uploads /app/logs /app/quarantine && \
-    chown -R clamav:clamav /app/quarantine
+RUN mkdir -p /app/uploads /app/logs
 
 # Set environment
 ENV NODE_ENV=production
 ENV PORT=3000
-ENV VIRUS_SCANNING_ENABLED=true
+ENV VIRUS_SCANNING_ENABLED=false
 
 # Expose port
 EXPOSE 3000
 
-# Health check using the comprehensive script that checks both Node.js and ClamAV
-HEALTHCHECK --interval=30s --timeout=15s --start-period=120s --retries=5 \
-    CMD /usr/local/bin/health-check.sh
+# Simple health check for Node.js app only
+HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
+    CMD curl -f http://localhost:3000/api/health || exit 1
 
-# Use supervisor to manage both Node.js app and ClamAV services
-CMD ["/usr/bin/supervisord", "-c", "/etc/supervisor/conf.d/supervisord.conf"] 
+# Run Node.js directly without supervisor
+CMD ["node", "dist/server/index.js"] 


### PR DESCRIPTION
- Remove ClamAV, supervisor, and related dependencies from Dockerfile.coolify
- Simplify container to run Node.js directly without supervisor
- Set VIRUS_SCANNING_ENABLED=false
- Update health check to only monitor Node.js app
- Reduce startup timeout from 120s to 60s
- Fixes 502 Bad Gateway errors caused by unhealthy container status